### PR TITLE
[Feat] Toast 컴포넌트 위치 조절을 위한 offset prop 추가

### DIFF
--- a/src/components/toast/Toast.styles.tsx
+++ b/src/components/toast/Toast.styles.tsx
@@ -12,9 +12,9 @@ const fadeIn = keyframes`
   }
 `
 
-export const ToastContainer = (position: 'top' | 'bottom' = 'bottom') => css`
+export const ToastContainer = (position: 'top' | 'bottom', offset: string) => css`
   position: fixed;
-  ${position === 'top' ? 'top: 24vh;' : 'bottom: 200px;'};
+  ${position === 'top' ? `top: ${offset};` : `bottom: ${offset};`}
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -7,15 +7,16 @@ import { createPortal } from 'react-dom'
 
 interface ToastProps {
   position?: 'top' | 'bottom'
+  offset?: string
 }
 
-const Toast = ({ position = 'bottom' }: ToastProps) => {
+const Toast = ({ position = 'bottom', offset = '200px' }: ToastProps) => {
   const { toast } = useToastStore()
 
   if (!toast) return null
 
   return createPortal(
-    <div css={ToastContainer(position)}>
+    <div css={ToastContainer(position, offset)}>
       <div css={ToastStyle}>
         {toast.type === 'success' ? (
           <FiCheckCircle color={colors.success} />

--- a/src/pages/inbox/LetterReceived/LetterReceived.tsx
+++ b/src/pages/inbox/LetterReceived/LetterReceived.tsx
@@ -73,7 +73,7 @@ const LetterReceived: FC<Props> = ({ uuid }) => {
       />
 
       <FallingLetters />
-      <Toast position='top' />
+      <Toast position='top' offset='24vh' />
     </div>
   )
 }

--- a/src/shared/ui/separated-input/separated-input.styles.tsx
+++ b/src/shared/ui/separated-input/separated-input.styles.tsx
@@ -24,5 +24,6 @@ export const separateInput = css`
 export const labels = css`
   font-size: 18px;
   font-weight: 700;
+  margin-bottom: 16px;
   color: ${colors.grey[1]};
 `


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

close #118

## 📋 작업 내용

Toast 컴포넌트의 위치를 유연하게 조정할 수 있도록 `position`과 `offset`을 props로 전달받아 동적으로 처리
- `Toast` 컴포넌트에서 `position`, `offset` prop을 받을 수 있도록 `ToastProps` 인터페이스 확장
- 기본값은 `position = 'bottom'`, `offset = '200px'`으로 설정

## 사용 예시

```tsx
// 기본 사용 (bottom 200px)
<Toast />

// top 위치로 변경
<Toast position="top" offset="10vh" />

// bottom 위치에서 위치 수정
<Toast offset="100px" />