### PR TITLE
[Fix] 페이지 새로고침시 store에 저장된 인증정보가 사라지는 문제 해결

### DIFF
--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,12 +1,23 @@
 import { create } from 'zustand'
-interface AuthStore {
+import { persist } from 'zustand/middleware'
+
+interface State {
   accessToken: string
+}
+interface Actions {
   deleteAccessToken: () => void
   setAccessToken: (accessToken: string) => void
 }
 
-export const useAuthStore = create<AuthStore>((set) => ({
-  accessToken: '',
-  deleteAccessToken: () => set({ accessToken: '' }),
-  setAccessToken: (accessToken) => set({ accessToken }),
-}))
+export const useAuthStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      accessToken: '',
+      deleteAccessToken: () => set({ accessToken: '' }),
+      setAccessToken: (accessToken) => set({ accessToken }),
+    }),
+    {
+      name: 'auth',
+    }
+  )
+)


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

Related to #141

## 📋 작업 내용

1. 새로고침 시 access token이 사라져서 다시 로그인해야 하는 문제를 해결했습니다.
    - ```zustand/middleware/persist```를 이용하여 local storage에 토큰 정보를 저장하는 것으로 새로고침 시에도 로그인 정보가 유지 되도록 수정했습니다
    - session storage와 비교하여 고민하던 중, session storage의 브라우저 탭 단위로 관리 되는 특징이 현 서비스 방향성과 맞지 않은 것으로 보여 local storage를 택했습니다.

2. store 관련 코드를 공식 문서에 나와있는 대로 방식으로 수정했습니다.
    - 커링을 사용하여 create 함수 생성
    - Store 타입을 State와 Actions로 나누어 관리


![시연](https://github.com/user-attachments/assets/d2bb2d3d-612f-4642-9071-670b17066f02)

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.
