### PR TITLE
[Feat] uuid 유효성 검증 훅 추가 및 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,11 +37,11 @@ const App = () => {
                   <Route path='choiceletter/:uuid/:id' element={<ChoiceLetter />} />
                   <Route path='sendletter/:uuid' element={<SendLetter />} />
                 </Route>
-                <Route path='/inbox/:uuid' element={<Inbox />} />
+                <Route path='inbox/:uuid' element={<Inbox />} />
                 <Route element={<AuthGuard />}>
-                  <Route path='/myletters/:uuid' element={<MyLetters />} />
-                  <Route path='/tryAnswer/:uuid/:id' element={<TryAnswer />} />
-                  <Route path='/checkanswer/:uuid/:id' element={<CheckAnswer />} />
+                  <Route path='myletters/:uuid' element={<MyLetters />} />
+                  <Route path='tryAnswer/:uuid/:id' element={<TryAnswer />} />
+                  <Route path='checkanswer/:uuid/:id' element={<CheckAnswer />} />
                 </Route>
               </Route>
               <Route path='*' element={<NotFound />} />

--- a/src/hooks/useValidateUuid.ts
+++ b/src/hooks/useValidateUuid.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { useAuthStore } from '#/store/authStore'
+import { useToastStore } from '#/store/toastStore'
+import { AxiosError } from 'axios'
+import { apiClient } from '#/api/apiClient'
+
+export const useValidateUuid = () => {
+  const { uuid } = useParams()
+  const navigate = useNavigate()
+  const { deleteAccessToken } = useAuthStore()
+  const { showToast } = useToastStore()
+
+  useEffect(() => {
+    const validate = async () => {
+      try {
+        await apiClient.get(`/users/${uuid}/status`)
+      } catch (error) {
+        if ((error as AxiosError).response?.status === 403) {
+          showToast('유효하지 않은 접근입니다.', 'error')
+          deleteAccessToken()
+          navigate('/')
+        }
+      }
+    }
+
+    validate()
+  }, [uuid, deleteAccessToken, navigate, showToast])
+}

--- a/src/pages/inbox/Inbox.tsx
+++ b/src/pages/inbox/Inbox.tsx
@@ -1,9 +1,12 @@
 // TODO:  uuid를 통해 형재 우체통이 유효한지 확인하는 로직 필요.
 import { useInboxStatus } from '#/hooks'
+import { useValidateUuid } from '#/hooks/useValidateUuid'
 import { LetterReceived, LetterReceiving } from '#/pages/inbox'
 import { useNavigate, useParams } from 'react-router'
 
 const Inbox = () => {
+  useValidateUuid()
+
   const navigate = useNavigate()
   const { uuid } = useParams()
 

--- a/src/pages/my-letters/MyLetters.tsx
+++ b/src/pages/my-letters/MyLetters.tsx
@@ -8,8 +8,11 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate, useParams } from 'react-router'
 import { BadgeStyle, GridContainer, MyLettersWrapper, TitleStyle } from './MyLetters.styles'
+import { useValidateUuid } from '#/hooks/useValidateUuid'
 
 const MyLetters = () => {
+  useValidateUuid()
+
   const { uuid } = useParams()
   const SCROLL_STORAGE_KEY = `myLettersScroll_${uuid}`
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #183 

## 📋 작업 내용

- uuid가 잘못된 경우 처리 로직을 공통 훅으로 분리후 적용
  - useValidateUuid 내부에서 status API 호출 후 403 발생 시 토스트 메시지 출력 및 홈(/)으로 리다이렉트 처리
  - inbox, myLetters 페이지에 useValidateUuid 훅 적용

기존 -> 빈화면
![Apr-12-2025 14-26-32](https://github.com/user-attachments/assets/420474c3-3299-4017-8164-31c8d55f8acb)

변경 후 -> 홈으로 리다이렉트 처리
![Apr-12-2025 14-26-25](https://github.com/user-attachments/assets/8a1815d4-feb2-4e83-b72e-8b3a5fab178e)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
