### PR TITLE
[fix]separatedInput의 backspace시 두번 눌러야 이전칸이 삭제되는 불편함 수정

### DIFF
--- a/src/shared/ui/separated-input/separated-input.tsx
+++ b/src/shared/ui/separated-input/separated-input.tsx
@@ -83,15 +83,22 @@ const SeparatedInput: React.FC<SeparatedInputProps> = ({
     // if (isComposing) return
 
     switch (e.key) {
-      case 'Backspace':
+      case 'Backspace': {
         e.preventDefault()
         const newValues = Array.from({ length }, (_, i) => value[i] ?? ' ')
-        newValues[index] = ' '
-        onChangeValue?.(newValues.join(''))
-        if (!e.currentTarget.value) {
+
+        if ((value[index] === '' || value[index] === ' ') && index > 0) {
+          // 현재 칸이 비어있으면 이전 칸 지우고 포커스
+          newValues[index - 1] = ' '
+          onChangeValue?.(newValues.join(''))
           inputRefs.current[index - 1]?.focus()
+        } else {
+          // 현재 칸만 지우기
+          newValues[index] = ' '
+          onChangeValue?.(newValues.join(''))
         }
         return
+      }
       case 'ArrowLeft':
         e.preventDefault() // 이동 시 focus가 글자 앞으로 가지 않도록
         inputRefs.current[index - 1]?.focus()


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안


## 📋 작업 내용

separatedInput의 backspace시 두번 눌러야 이전칸이 삭제되는 불편함 수정

## 🔧 변경 사항
현재 칸이 비어있으면 이전 칸 지우고 포커스



## 📸 스크린샷 (선택 사항)

[수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.](https://github.com/user-attachments/assets/79020571-9731-4d21-914d-98d0c13368af)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.



