### PR TITLE
[refactor] 폰트 깜빡임 현상 방지를 위해 font-display block 추가 

### DIFF
--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -17,55 +17,68 @@ const fontStyles = css`
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 100;
-    src: url(${Thin}) format (woff);
+    src: url(${Thin}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 200;
-    src: url(${ExtraLight}) format(woff);
+    src: url(${ExtraLight}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 300;
-    src: url(${Light}) format(woff);
+    src: url(${Light}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 400;
-    src: url(${Regular}) format(woff);
+    src: url(${Regular}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 500;
-    src: url(${Medium}) format(woff);
+    src: url(${Medium}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 600;
-    src: url(${SemiBold}) format(woff);
+    src: url(${SemiBold}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 700;
-    src: url(${Bold}) format(woff);
+    src: url(${Bold}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 800;
-    src: url(${ExtraBold}) format(woff);
+    src: url(${ExtraBold}) format('woff');
+    font-display: block;
   }
   @font-face {
     font-family: 'NotoSansKR';
     font-weight: 900;
-    src: url(${BlackBold}) format(woff);
+    src: url(${BlackBold}) format('woff');
+    font-display: block;
   }
+
   @font-face {
     font-family: 'NanumPen';
-    src: url(${NanumPen}) format(woff);
+    src: url(${NanumPen}) format('woff');
+    font-display: block;
   }
+
   @font-face {
     font-family: 'Ownglyph';
-    src: url(${OwnglyphEuiyeon}) format(woff);
+    src: url(${OwnglyphEuiyeon}) format('woff');
+    font-display: block;
   }
 `
 export default fontStyles


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

편지지 선택 페이지에서 폰트 카테고리 선택시 글씨체가 늦게 렌더링되는 현상 발생
폰트가 정의된 font.ts에 font-display:block 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
