### PR TITLE
fix: success 페이지 내 보여지는 완성된 우체통 url 부분 정규표현식을 통한 inbox 경로 추가 (#254)

### DIFF
--- a/src/pages/success/Success.tsx
+++ b/src/pages/success/Success.tsx
@@ -16,6 +16,11 @@ const Success = () => {
   const user = location.state
   const { isOpen, openModal, closeModal } = useModal()
   // const { leftTime } = useCountdownTimer(user.expired)
+
+  //생성된 우체통 URL 표시용 변수
+  const displayMailboxUrl = user.mailboxUrl.replace(/(https?:\/\/[^/]+)\/(.+)$/, '$1/inbox/$2')
+
+  //생성된 우체통의 uuid
   const uuidMatch = user.mailboxUrl.match(/[^/]+$/)
 
   const onClickBtnPost = () => {
@@ -36,7 +41,11 @@ const Success = () => {
         <div className='area_desc'>
           <h1 className='create_link'>{t('create.link')}</h1>
           <h2 className='create_link_desc'>{t('create.linkShere')}</h2>
-          <DescLink link={user.mailboxUrl} btnName={t('create.btncopy')} desc={t('create.desc')} />
+          <DescLink
+            link={displayMailboxUrl}
+            btnName={t('create.btncopy')}
+            desc={t('create.desc')}
+          />
           {/* <DescWithNum className='second' number={2}>
             {t('create.opentime')} <TimeArea time={leftTime} /> <br />
             {t('create.check')}
@@ -49,7 +58,7 @@ const Success = () => {
           {t('create.btnshare')}
         </Button>
       </div>
-      <ShareModal isOpen={isOpen} onClose={closeModal} url={user.mailboxUrl} />
+      <ShareModal isOpen={isOpen} onClose={closeModal} url={displayMailboxUrl} />
     </div>
   )
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
 
우체통 생성 완료 페이지 상단에 표시되는 우체통 URL에서 /inbox 경로가 누락되어 링크를 직접 복사하거나 공유 모달을 통해 우체통 링크를 전달할 경우 존재하지 않는 페이지로 이동하는 문제가 발생했습니다.
서버 측에 URL 형식 수정을 요청했으나 현재 재배포 작업이 어렵다는 답변을 들어 우선적으로 사용자 접근 오류를 해결하기 위해 프론트엔드 단에서 아래와 같이 대응을 진행했습니다.

서버에서 전달받은 URL을 정규표현식으로 파싱하여 도메인과 UUID를 분리한 뒤 두 값 사이에 /inbox 경로를 삽입해 정상적인 우체통 URL 형식으로 변환하도록 처리했습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
